### PR TITLE
Evenmoar

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,7 +68,7 @@ Vagrant.configure("2") do |config|
 
       yum install -y epel-release
       yum update -y
-      yum install -y bash-completion htop yum-utils
+      yum install -y bash-completion htop yum-utils git
       yum install -y python39
       alternatives --set python3 /usr/bin/python3.9
       pip3 install --upgrade pip setuptools virtualenv
@@ -92,6 +92,7 @@ Vagrant.configure("2") do |config|
       rm -fr roles/geerlingguy.nginx/ 
       rm -fr roles/geerlingguy.repo-epel/
       rm -fr roles/geerlingguy.redis/
+      rm -fr roles/avanov.pyenv/
 
       ansible-galaxy install --role-file=prereq_roles.yml --roles-path=/home/vagrant/dev_playbook/roles --force 
       ANSIBLE_CONFIG="/home/vagrant/dev_playbook/ansible.cfg" /home/vagrant/.local/bin/ansible-playbook /home/vagrant/dev_playbook/playbook.yml -i /home/vagrant/dev_playbook/inventory.ini

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,31 +13,56 @@ Vagrant.configure("2") do |config|
   # thinking that we actually want to use the default insecure ssh keys for both VMs
   config.ssh.insert_key = false
 
-  # config.vm.provider "virtualbox" do |vb|
-  #   # vb.gui = true
-  #   vb.cpus = 2 # two cores
-  #   vb.memory = "4096"
-  # end
 
-  
-  config.vm.define "dev1" do |dev|
-    dev.vm.box = "generic/rocky8"
+  config.vm.define "dev1rocky" do |dev|
+    dev.vm.box = "generic/rocky9"
 
     dev.vm.provider "virtualbox" do |dev_vb| # lol, visual basic.
       dev_vb.cpus = 2
       dev_vb.memory = "4096"
-    end 
+    end
 
-    dev.vm.hostname = 'dev1.lan'
+    dev.vm.hostname = 'dev1rocky.lan'
     dev.vm.network "private_network", ip: "192.168.69.69" # niiiiiice
 
     dev.vm.synced_folder "./keys", "/home/vagrant/keys"
-    # Virtualbox's support of shared folders in/out of the VM is pretty shoddy. 
+    # Virtualbox's support of shared folders in/out of the VM is pretty shoddy.
     # NOT YET dev.vm.synced_folder File.join(ENV['HOMEPATH'], 'code'), "/home/vagrant/code"
 
-    # NOT YET dev.vm.network "forwarded_port", guest: 3000, host: 3000, host_ip: "127.0.0.1"
-    # NOT YET dev.vm.network "forwarded_port", guest: 3035, host: 3035, host_ip: "127.0.0.1"
-    # NOT YET dev.vm.network "forwarded_port", guest: 5432, host: 54321, host_ip: "127.0.0.1"
+    # dev.vm.network "forwarded_port", guest: 3000, host: 3000, host_ip: "127.0.0.1"
+    # dev.vm.network "forwarded_port", guest: 3035, host: 3035, host_ip: "127.0.0.1"
+    # dev.vm.network "forwarded_port", guest: 5432, host: 5432, host_ip: "127.0.0.1"
+    # dev.vm.network "forwarded_port", guest: 9292, host: 9292, host_ip: "127.0.0.1"
+
+    dev.vm.provision "shell", inline: <<-SHELL
+      sudo --user=vagrant --login mkdir -p /home/vagrant/.ssh
+      sudo --user=vagrant --login chmod 700 /home/vagrant/.ssh
+      sudo --user=vagrant --login cat /home/vagrant/keys/id_rsa.pub >> /home/vagrant/.ssh/authorized_keys
+      echo "alias ls='ls -alh --color=auto'" >> .bashrc
+
+    SHELL
+  end
+
+    config.vm.define "dev1ubuntu" do |dev|
+    dev.vm.box = "generic/ubuntu2210"
+
+    dev.vm.provider "virtualbox" do |dev_vb| # lol, visual basic.
+      dev_vb.cpus = 2
+      dev_vb.memory = "4096"
+      dev_vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    end
+
+    dev.vm.hostname = 'dev1ubuntu.lan'
+    dev.vm.network "private_network", ip: "192.168.69.70" # niiiiiice
+
+    dev.vm.synced_folder "./keys", "/home/vagrant/keys"
+    # Virtualbox's support of shared folders in/out of the VM is pretty shoddy.
+    # NOT YET dev.vm.synced_folder File.join(ENV['HOMEPATH'], 'code'), "/home/vagrant/code"
+
+    # dev.vm.network "forwarded_port", guest: 3000, host: 3000, host_ip: "127.0.0.1"
+    # dev.vm.network "forwarded_port", guest: 3035, host: 3035, host_ip: "127.0.0.1"
+    # dev.vm.network "forwarded_port", guest: 5432, host: 5432, host_ip: "127.0.0.1"
+    # dev.vm.network "forwarded_port", guest: 9292, host: 9292, host_ip: "127.0.0.1"
 
     dev.vm.provision "shell", inline: <<-SHELL
       sudo --user=vagrant --login mkdir -p /home/vagrant/.ssh
@@ -50,15 +75,15 @@ Vagrant.configure("2") do |config|
 
 
   config.vm.define "ans1" do |ans|
-    ans.vm.box = "generic/rocky8"
+    ans.vm.box = "generic/rocky9"
 
-    ans.vm.provider "virtualbox" do |ans_vb| 
+    ans.vm.provider "virtualbox" do |ans_vb|
       ans_vb.cpus = 1
       ans_vb.memory = "512"
     end
 
     ans.vm.hostname = 'ans1.lan'
-    ans.vm.network "private_network", ip: "192.168.69.2"
+    ans.vm.network "private_network", ip: "192.168.69.42"
 
     ans.vm.synced_folder "./dev_playbook", "/home/vagrant/dev_playbook"
     ans.vm.synced_folder "./keys", "/home/vagrant/keys"
@@ -68,37 +93,37 @@ Vagrant.configure("2") do |config|
       sudo --user=vagrant --login cp /home/vagrant/keys/id_rsa* /home/vagrant/.ssh && chmod 600 /home/vagrant/.ssh/id_rsa
       echo "alias ls='ls -alh --color=auto'" >> .bashrc
 
-      yum install -y epel-release
-      yum update -y
-      yum install -y bash-completion htop yum-utils git
-      yum install -y python39
-      alternatives --set python3 /usr/bin/python3.9
+      dnf install -y epel-release
+      dnf update -y
+      dnf install -y bash-completion htop yum-utils git
+      dnf install -y python3 python3-pip
+      # alternatives --set python3 /usr/bin/python3.9
       pip3 install --upgrade pip setuptools virtualenv
       sudo --user=vagrant --login python3 -m pip install --user ansible
     SHELL
 
-    ans.vm.provision "shell", name: 'provision dev1 using ansible inside ans1', after: 'install ansible', communicator_required: true, privileged: false, inline: <<-SHELL
-      # echo "----------------------------------------"
-      # echo "SSH into this host with:"
-      # echo "  vagrant ssh ans1"
-      # echo ""
-      # echo "Provision the development VM with:"
-      # echo "  cd /home/vagrant/dev_playbook && ANSIBLE_CONFIG="./ansible.cfg" /home/vagrant/.local/bin/ansible-playbook playbook.yml -i inventory.ini"
-      # echo ""
-      # echo "----------------------------------------"
-      
-      cd /home/vagrant/dev_playbook
-      rm -fr roles/zzet.rbenv/
-      rm -fr roles/stephdewit.nvm/
-      rm -fr roles/geerlingguy.memcached/
-      rm -fr roles/geerlingguy.nginx/ 
-      rm -fr roles/geerlingguy.repo-epel/
-      rm -fr roles/geerlingguy.redis/
-      rm -fr roles/avanov.pyenv/
+    # ans.vm.provision "shell", name: 'provision dev1 using ansible inside ans1', after: 'install ansible', communicator_required: true, privileged: false, inline: <<-SHELL
+    #   # echo "----------------------------------------"
+    #   # echo "SSH into this host with:"
+    #   # echo "  vagrant ssh ans1"
+    #   # echo ""
+    #   # echo "Provision the development VM with:"
+    #   # echo "  cd /home/vagrant/dev_playbook && ANSIBLE_CONFIG="./ansible.cfg" /home/vagrant/.local/bin/ansible-playbook playbook.yml -i inventory.ini"
+    #   # echo ""
+    #   # echo "----------------------------------------"
 
-      ansible-galaxy install --role-file=prereq_roles.yml --roles-path=/home/vagrant/dev_playbook/roles --force 
-      ANSIBLE_CONFIG="/home/vagrant/dev_playbook/ansible.cfg" /home/vagrant/.local/bin/ansible-playbook /home/vagrant/dev_playbook/playbook.yml -i /home/vagrant/dev_playbook/inventory.ini
-    SHELL
+    #   cd /home/vagrant/dev_playbook
+    #   rm -fr roles/zzet.rbenv/
+    #   rm -fr roles/stephdewit.nvm/
+    #   rm -fr roles/geerlingguy.memcached/
+    #   rm -fr roles/geerlingguy.nginx/
+    #   rm -fr roles/geerlingguy.repo-epel/
+    #   rm -fr roles/geerlingguy.redis/
+    #   rm -fr roles/avanov.pyenv/
+
+    #   ansible-galaxy install --role-file=prereq_roles.yml --roles-path=/home/vagrant/dev_playbook/roles --force
+    #   ANSIBLE_CONFIG="/home/vagrant/dev_playbook/ansible.cfg" /home/vagrant/.local/bin/ansible-playbook /home/vagrant/dev_playbook/playbook.yml -i /home/vagrant/dev_playbook/inventory.ini
+    # SHELL
   end
-  # beg/borrow/steal ideas from https://github.com/ValveSoftware/Proton/blob/proton_6.3/Vagrantfile
+  # beg/borrowed/stole ideas from https://github.com/ValveSoftware/Proton/blob/proton_6.3/Vagrantfile
 end

--- a/dev_playbook/inventory.ini
+++ b/dev_playbook/inventory.ini
@@ -1,2 +1,8 @@
 [dev]
 192.168.69.69
+
+; we'll be installing pyenv on the dev machine(s).
+; this makes ansible unhappy when it reaches into the dev machines to provision them. 
+; Explicitly telling it to use the system-installed python makes it happy.
+[dev:vars]
+ansible_python_interpreter=/usr/bin/python3

--- a/dev_playbook/inventory.ini
+++ b/dev_playbook/inventory.ini
@@ -1,8 +1,9 @@
 [dev]
 192.168.69.69
+192.168.69.70
 
 ; NOT YET ; we'll be installing pyenv on the dev machine(s).
-; NOT YET; this makes ansible unhappy when it reaches into the dev machines to provision them. 
+; NOT YET; this makes ansible unhappy when it reaches into the dev machines to provision them.
 ; NOT YET; Explicitly telling it to use the system-installed python makes it happy.
 ; NOT YET[dev:vars]
 ; NOT YETansible_python_interpreter=/usr/bin/python3

--- a/dev_playbook/playbook.yml
+++ b/dev_playbook/playbook.yml
@@ -1,161 +1,84 @@
 ---
 - hosts: dev
-  become: yes
+  become: true
+  become_method: sudo
 
-  # before running, make sure you install the prereq roles with: 
-  # ansible-galaxy install --roles-path=roles --role-file=ansible_prereq_roles.yml --force
+  # before running, make sure you install the prereq roles with:
+  # ansible-galaxy install --roles-path=roles --role-file=prereq_roles.yml --force
   #
-  # then run with something like: 
-  # ANSIBLE_CONFIG='.ansible.cfg' ansible-playbook playbook.yml -i inventory.ini
+  # then run with something like:
+  # ANSIBLE_CONFIG='./ansible.cfg' ANSIBLE_INVENTORY='./inventory.ini' ansible-playbook playbook.yml
 
   pre_tasks:
-    - name: Yummy Dev Tools
-      yum: 
-        enablerepo:
-          - epel-release
-          - powertools
-        update_cache: yes 
-        state: latest 
-        name: "{{ item }}"
-      with_items:
-        - bash-completion
-        - htop 
-        - yum-utils 
-        - "@Development Tools"
-        - python39
-        - libyaml-devel
-        - python39-psycopg2
-        - freetds
-        - sassc
-        - libyaml
-        - libffi
-        - graphviz 
-        - graphviz-devel
-
-    - name: Symlink python3 to python3.9
-      alternatives: 
-        name: python3
-        path: /usr/bin/python3.9
-
-    - name: Update pip and setuptools
-      pip: 
-        name: "{{ item }}"
-        state: latest # ie: "pip3 install --upgrade"
-      with_items: 
-        - pip
-        - setuptools
+    - include_tasks: tasks/system-dependencies-rhel.yml
+      when: (ansible_pkg_mgr == "yum" or ansible_pkg_mgr == "dnf") and (ansible_distribution == "Rocky" or ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "OracleLinux")
+    - include_tasks: "tasks/system-dependencies-ubuntu.yml"
+      when: ansible_pkg_mgr == "apt" and ansible_distribution == "Ubuntu"
 
   roles:
-    # NOT YET- role: avanov.pyenv
-    # NOT YET  pyenv_env: system
-    # NOT YET  pyenv_path: /usr/local/pyenv
-    # NOT YET  pyenv_owner: vagrant
-    # NOT YET  pyenv_python_versions: 
-    # NOT YET    - 3.8.13
-    # NOT YET    - 3.9.13
-    # NOT YET    - 3.10.4
-    # NOT YET  pyenv_global: 3.10.4
-    # NOT YET  pyenv_virtualenvs:
-    # NOT YET    - venv_name: latest
-    # NOT YET      py_version: 3.10.4
-
-    - role: geerlingguy.memcached
-    
-    - role: geerlingguy.redis
-
-    # would like to use ANXS.postgresql role, but their latest version in ansible-galaxy is outdated.
-    # roles/sd.postgresql is our own extract of their repository...seems to work.
-    - role: sd.postgresql
-      postgresql_users: 
-        - name: vagrant
-          pass: vagrant
-          encrypted: yes
-          state: present
-      postgresql_user_privileges:
-        - name: vagrant
-          role_attr_flags: SUPERUSER
-
-
-    # system-wide rbenv for managing ruby versions
+    - role: staticdev.pyenv
+      vars:
+        pyenv_env: user
+        pyenv_path: "/home/vagrant/.pyenv"
+        pyenv_owner: vagrant
+        pyenv_owner_group: vagrant
+        pyenv_python_versions:
+          - "3.10.12"
+        pyenv_global:
+          - "3.10.12"
+        pyenv_shellrc_file: "/home/vagrant/.bashrc"
     - role: zzet.rbenv
-      rbenv:
-        env: system
-        version: v1.2.0
-        default_ruby: 3.1.2
-        rubies:
-          - version: 2.6.10
-          - version: 2.7.6
-          - version: 3.0.4
-          - version: 3.1.2
-      rbenv_clean_up: true
-      rbenv_plugins: 
-        - { name: "rbenv-vars",         repo: "https://github.com/rbenv/rbenv-vars.git",         version: "master" }
-        - { name: "ruby-build",         repo: "https://github.com/rbenv/ruby-build.git",         version: "master" }
-        - { name: "rbenv-default-gems", repo: "https://github.com/rbenv/rbenv-default-gems.git", version: "master" }
-        - { name: "rbenv-installer",    repo: "https://github.com/rbenv/rbenv-installer.git",    version: "main" }
-        - { name: "rbenv-update",       repo: "https://github.com/rkh/rbenv-update.git",         version: "master" }
-        - { name: "rbenv-whatis",       repo: "https://github.com/rkh/rbenv-whatis.git",         version: "master" }
-        - { name: "rbenv-use",          repo: "https://github.com/rkh/rbenv-use.git",            version: "master" }
-        - { name: 'rbenv-bundle-exec',  repo: "https://github.com/maljub01/rbenv-bundle-exec",   version: "master" }
-      rbenv_owner: root
-      rbenv_group: vagrant
+      vars:
+        rbenv:
+          env: user
+          version: v1.2.0
+          default_ruby: 3.2.2
+          rubies:
+            - version: 2.7.8
+            - version: 3.0.6
+            - version: 3.1.4
+            - version: 3.2.2
+            - version: 3.3.0
+        rbenv_users:
+          - vagrant
+        rbenv_plugins:
+          - { name: "ruby-build",         repo: "https://github.com/rbenv/ruby-build.git",         version: "master" }
+          - { name: "rbenv-installer",    repo: "https://github.com/rbenv/rbenv-installer.git",    version: "main" }
+          - { name: "rbenv-update",       repo: "https://github.com/rkh/rbenv-update.git",         version: "master" }
+        rbenv_clean_up: false
+
+    # - role: geerlingguy.memcached
+    # - role: geerlingguy.redis
+    # # would like to use ANXS.postgresql role, but their latest version in ansible-galaxy is outdated.
+    # # roles/sd.postgresql is our own extract of their repository...seems to work.
+    # - role: sd.postgresql
+    #   postgresql_users:
+    #     - name: vagrant
+    #       pass: vagrant
+    #       encrypted: yes
+    #       state: present
+    #   postgresql_user_privileges:
+    #     - name: vagrant
+    #       role_attr_flags: SUPERUSER
 
     # vagrant-user-only nvm for managing node(i can't make it work system-wide...not gonna fight it.)
     - role: stephdewit.nvm
-      nvm_version: latest
-      nvm_node_version: 17.6.0
-      nvm_install_path: "/home/vagrant/.nvm"
-      nvm_shell_init_file: "/home/vagrant/.bashrc"
-      environment:
-        NVM_DIR: "/home/vagrant/.nvm"
+      vars:
+        nvm:
+          node_version: "18.6.0"
+          install_for: vagrant
+          install_info: "/home/vagrant/.nvm"
+        nvm_version: latest
+        nvm_node_version: "18.6.0"
+        nvm_install_path: "/home/vagrant/.nvm"
+        nvm_shell_init_file: "/home/vagrant/.bashrc"
+        environment:
+          NVM_DIR: "/home/vagrant/.nvm"
 
   tasks:
+    - include_tasks: 'tasks/nvm.yml'
 
-    - name: Symlink pg_config into /usr/bin
-      alternatives: 
-        name: pg_config
-        link: /usr/bin/pg_config
-        path: /usr/pgsql-13/bin/pg_config
+    - include_tasks: 'tasks/git-bash-prompt.yml'
 
-    - name: Instal PG dev tools
-      yum: 
-        state: latest 
-        name: postgresql13-devel
 
-    - name: Update rbenv-bundle-exec plugin ~/.no_bundle_exec
-      copy: 
-        src: files/no_bundle_exec
-        dest: /home/vagrant/.no_bundle_exec
-        owner: vagrant
-        group: vagrant
-        mode: 0644 
 
-    # Monkey with permissions of /usr/local/rbenv
-    # zzet.rbenv does an ok job on the permissions, but it doesn't grant the rbenv_group write
-    # permissions to _everything_ that it should.
-    # leave /usr/local/rbenv owned by root, but change to vagrant group ownership,
-    # also change directories to 0776 and files to 0664.
-    - name: Update /usr/local/rbenv to ensure appropriate permissions
-      file:
-        path: /usr/local/rbenv
-        group: vagrant
-        mode: u=rwX,g=rwX,o=rX
-        recurse: yes
-
-    - name: Update nvm directory to ensure appropriate permissions
-      file:
-        path: "/home/vagrant/.nvm"
-        state: directory
-        recurse: yes
-        owner: "vagrant"
-        group: "vagrant"
-
-    - name: Update nvm default-packages
-      copy: 
-        src: files/default-packages
-        dest: /home/vagrant/.nvm/default-packages
-        owner: vagrant
-        group: vagrant
-        mode: 0644 
-
-  

--- a/dev_playbook/playbook.yml
+++ b/dev_playbook/playbook.yml
@@ -44,6 +44,19 @@
         - setuptools
 
   roles:
+    - role: avanov.pyenv
+      pyenv_env: system
+      pyenv_path: /usr/local/pyenv
+      pyenv_owner: vagrant
+      pyenv_python_versions: 
+        - 3.8.13
+        - 3.9.13
+        - 3.10.4
+      pyenv_global: 3.10.4
+      pyenv_virtualenvs:
+        - venv_name: latest
+          py_version: 3.10.4
+
     - role: geerlingguy.memcached
     
     - role: geerlingguy.redis
@@ -95,6 +108,17 @@
         NVM_DIR: "/home/vagrant/.nvm"
 
   tasks:
+
+    - name: Symlink pg_config into /usr/bin
+      alternatives: 
+        name: pg_config
+        link: /usr/bin/pg_config
+        path: /usr/pgsql-13/bin/pg_config
+
+    - name: Instal PG dev tools
+      yum: 
+        state: latest 
+        name: postgresql13-devel
 
     - name: Update rbenv-bundle-exec plugin ~/.no_bundle_exec
       copy: 

--- a/dev_playbook/prereq_roles.yml
+++ b/dev_playbook/prereq_roles.yml
@@ -1,6 +1,9 @@
-- src: zzet.rbenv
-- src: stephdewit.nvm
+- src: https://github.com/avanov/ansible-galaxy-pyenv
+  version: master
+  name: avanov.pyenv
 - src: geerlingguy.memcached
 - src: geerlingguy.nginx
-- src: geerlingguy.repo-epel
 - src: geerlingguy.redis
+- src: geerlingguy.repo-epel
+- src: stephdewit.nvm
+- src: zzet.rbenv

--- a/dev_playbook/prereq_roles.yml
+++ b/dev_playbook/prereq_roles.yml
@@ -1,9 +1,7 @@
-- src: https://github.com/avanov/ansible-galaxy-pyenv
-  version: master
-  name: avanov.pyenv
-- src: geerlingguy.memcached
-- src: geerlingguy.nginx
-- src: geerlingguy.redis
-- src: geerlingguy.repo-epel
+- src: staticdev.pyenv
+# - src: geerlingguy.memcached
+# - src: geerlingguy.nginx
+# - src: geerlingguy.redis
+# - src: geerlingguy.repo-epel
 - src: stephdewit.nvm
 - src: zzet.rbenv

--- a/dev_playbook/tasks/git-bash-prompt.yml
+++ b/dev_playbook/tasks/git-bash-prompt.yml
@@ -1,0 +1,16 @@
+- name: install bash git prompt
+  git:
+    repo: https://github.com/magicmonty/bash-git-prompt.git
+    dest: /home/vagrant/.bash-git-prompt
+    depth: 1
+
+- name: Enable bash git prompt in .bashrc
+  blockinfile:
+    path: /home/vagrant/.bashrc
+    marker: "# {mark} ANSIBLE MANAGED BLOCK"
+    block: |
+      if [ -f "$HOME/.bash-git-prompt/gitprompt.sh" ]; then
+        GIT_PROMPT_ONLY_IN_REPO=1
+        GIT_PROMPT_SHOW_UPSTREAM=1
+        source $HOME/.bash-git-prompt/gitprompt.sh
+      fi

--- a/dev_playbook/tasks/nvm.yml
+++ b/dev_playbook/tasks/nvm.yml
@@ -1,0 +1,36 @@
+# CYA against us or stephdewitt's role leaving anything with root:root owernship
+- name: Update nvm permissions
+  file:
+    path: "/home/vagrant/.nvm"
+    state: directory
+    recurse: yes
+    owner: vagrant
+    group: vagrant
+
+- name: Touch nvm default-packages file
+  become_user: vagrant
+  file:
+    path: "/home/vagrant/.nvm/default-packages"
+    state: touch
+    mode: '0644'
+    modification_time: preserve
+    access_time: preserve
+    owner: vagrant
+    group: vagrant
+
+- name: Ensure yarn is an nvm default-package
+  become_user: vagrant
+  blockinfile:
+    dest: "/home/vagrant/.nvm/default-packages"
+    block: |
+      yarn
+  register: default_packages_updated
+
+- name: Ensure nvm default-packages are installed
+  become_user: vagrant
+  shell: |
+    . /home/vagrant/.nvm/nvm.sh
+    nvm use 18.6.0
+    nvm exec 18.6.0 npm install --global yarn
+  environment:
+    NVM_DIR: "/home/vagrant/.nvm"

--- a/dev_playbook/tasks/system-dependencies-rhel.yml
+++ b/dev_playbook/tasks/system-dependencies-rhel.yml
@@ -1,0 +1,55 @@
+# This playbook ensures system tools and libraries are installed that I
+# commonly make use of.
+# Install dependencies for RHEL based systems
+- name: RHEL System Dependencies
+  yum:
+    enablerepo:
+      - appstream
+      - crb
+      - epel
+      - extras
+    update_cache: true
+    state: latest
+    name: "{{ item }}"
+  with_items:
+    - "@Development Tools"
+    - cifs-utils                      # Mounting Window CIFS volumes
+    - compat-openssl11                # OpenSSL 1.1 compatibility libs
+    - freetds                         # MSSQL stuff
+    - freetds-devel                   # MSSQL stuff
+    - freetds-libs                    # MSSQL stuff
+    - gdbm-libs
+    - gdbm-devel
+    - git                             #
+    - ImageMagick                     # CLI image manip stuff
+    - ImageMagick-devel               # CLI image manip stuff
+    - ImageMagick-libs                # CLI image manip stuff
+    - libffi                          # Foreign-Function Interface
+    - libmemcached-awesome            # Memcached stuff
+    - libmemcached-awesome-tools      # Memcached stuff
+    - libpq                           # PostgreSQL libs
+    - libpq-devel                     # PostgreSQL libs
+    - libsass                         # SASS libs
+    - libsass-devel                   # SASS libs
+    - libyaml                         # YAML libs
+    - libyaml-devel                   # YAML libs
+    - openssl                         # OpenSSL 3 stuff
+    - openssl-devel                   # OpenSSL 3 stuff
+    - openssl-libs                    # OpenSSL 3 stuff
+    - perl-FindBin                    # Dunno why...need this sometimes
+    - postgresql                      # PostgreSQL CLI tools
+    - readline                        # Readline stuff
+    - readline-devel                  # Readline stuff
+    - redis                           # Redis - want CLI tools only, but this also installs server (disabled below)
+    - redis-devel                     # Redis - want CLI tools only, but this also installs server (disabled below)
+    - sassc                           # SASSC stuff
+    - shared-mime-info                # Mime stuff
+
+
+# We install redis because I want the redis-cli tools. However, I don't want
+# the redis service running.  Make sure that's off and disabled.
+- name: "RHEL: Ensure Redis is disabled"
+  service:
+    name: redis
+    state: stopped
+    enabled: false

--- a/dev_playbook/tasks/system-dependencies-ubuntu.yml
+++ b/dev_playbook/tasks/system-dependencies-ubuntu.yml
@@ -1,0 +1,49 @@
+# This playbook ensures system tools and libraries are installed that I
+# commonly make use of.
+
+
+
+# Install dependencies for Ubuntu based systems
+- name: Download apt key
+  get_url:
+    url:  https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    dest: /tmp
+
+- name: Add apt key from file
+  apt_key:
+    file: /tmp/apt-key.gpg
+    state: present
+
+
+- name: Ubuntu System Dependencies
+  apt:
+    update_cache: true
+    state: latest
+    name: "{{ item }}"
+  with_items:
+    - "build-essential"
+    - cifs-utils                      # Mounting Window CIFS volumes
+    # - compat-openssl11                # OpenSSL 1.1 compatibility libs
+    - freetds-bin                     # MSSQL stuff
+    - freetds-common                  # MSSQL stuff
+    - freetds-dev                     # MSSQL stuff
+    - git                             #
+    - imagemagick                     # CLI image manip stuff
+    - libffi8                          # Foreign-Function Interface
+    - libffi-dev                      # Foreign-Function Interface
+    - libmemcached-dev                # Memcached stuff
+    - libmemcached-tools              # Memcached stuff
+    - libpq5                           # PostgreSQL libs
+    - libpq-dev                       # PostgreSQL libs
+    - libsass1                         # SASS libs
+    - libsass-dev                     # SASS libs
+    - libyaml-0-2                         # YAML libs
+    - libyaml-dev                     # YAML libs
+    - openssl                         # OpenSSL 3 stuff
+    - postgresql-client               # PostgreSQL CLI tools
+    - postgresql-client-common        # PostgreSQL CLI tools
+    - readline-common                 # Readline stuff
+    - redis-tools                     # Redis - want CLI tools only
+    - sassc                           # SASSC stuff
+    - shared-mime-info                # Mime stuff
+


### PR DESCRIPTION
Haven't updated in a while. 

This PR
- Bumps up from Rocky 8 to Rocky 9. 
- Takes some stuff out (no PG, memcached, redis installs, for example.) 
- Gets pyenv installed and working. 
- Refactors some stuff around. 
- Spins up 3 VMs now. 
  - 1 thin `ans1` VM (running [Rocky 9](https://app.vagrantup.com/generic/boxes/rocky9)) for running ansible against:
  - 1 `dev1rocky` based on [generic/rocky9](https://app.vagrantup.com/generic/boxes/rocky9)
  - 1 `dev1ubuntu` based on [generic/ubuntu2210](https://app.vagrantup.com/generic/boxes/ubuntu2210)

Getting Ubuntu in there because the business abandoned CentOS in favor of Rocky only to discover they still weren't happy with the state of things, and are moving to Ubuntu Server.  Figured I should get things working ahead of schedule...